### PR TITLE
Add CHECK-LABEL to avoid source tree path sensitivity in test

### DIFF
--- a/clang/test/CodeGen/2004-02-20-Builtins.c
+++ b/clang/test/CodeGen/2004-02-20-Builtins.c
@@ -3,6 +3,9 @@ double sqrt(double x);
 
 // CHECK-LABEL: @zsqrtxxx
 // CHECK-NOT: builtin
+// Don't search into metadata definitions.  !llvm.ident can contain the
+// substring "builtin" if it's in the source tree path.
+// CHECK-LABEL: !llvm.ident
 void zsqrtxxx(float num) {
    num = sqrt(num);
 }


### PR DESCRIPTION
The test `clang/test/CodeGen/2004-02-20-Builtins.c` will erroneously fail if "builtin" is in the path to your source tree.

This change adds a `CHECK-LABEL !llvm.ident` after the `CHECK-NOT` to avoid searching into the metadata containing the path.